### PR TITLE
Fixing small bugs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,6 +40,15 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - name: Compute ref slug
+              id: ref
+              shell: bash
+              run: |
+                  ref="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+                  slug=$(echo "$ref" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9._-]+#-#g; s#-+#-#g; s#^[-.]++##; s#[-.]++$##')
+                  echo "branch=$ref" >> "$GITHUB_OUTPUT"
+                  echo "slug=$slug" >> "$GITHUB_OUTPUT"
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
 
@@ -56,9 +65,14 @@ jobs:
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/cli
                   tags: |
-                      type=ref,event=branch
-                      type=ref,event=pr
-                      type=sha,prefix={{branch}}-
+                      # explicit branch tag (slugged) for both push and PR
+                      type=raw,value=${{ steps.ref.outputs.slug }},enable=true
+                      # PR number tag on PR events
+                      type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ startsWith(github.ref, 'refs/pull/') }}
+                      # branch-slug + short sha
+                      type=raw,value=${{ steps.ref.outputs.slug }}-${{ github.sha }},enable=true
+                      # plain sha tag
+                      type=sha
 
             - name: Build and push CLI image
               uses: docker/build-push-action@v5
@@ -84,6 +98,15 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - name: Compute ref slug
+              id: ref
+              shell: bash
+              run: |
+                  ref="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+                  slug=$(echo "$ref" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9._-]+#-#g; s#-+#-#g; s#^[-.]++##; s#[-.]++$##')
+                  echo "branch=$ref" >> "$GITHUB_OUTPUT"
+                  echo "slug=$slug" >> "$GITHUB_OUTPUT"
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
 
@@ -100,9 +123,10 @@ jobs:
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/daemon
                   tags: |
-                      type=ref,event=branch
-                      type=ref,event=pr
-                      type=sha,prefix={{branch}}-
+                      type=raw,value=${{ steps.ref.outputs.slug }},enable=true
+                      type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ startsWith(github.ref, 'refs/pull/') }}
+                      type=raw,value=${{ steps.ref.outputs.slug }}-${{ github.sha }},enable=true
+                      type=sha
 
             - name: Build and push daemon image
               uses: docker/build-push-action@v5

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,11 +33,13 @@ jobs:
               run: |
                   ./stamusctl compose init tests --default
                   ./stamusctl compose up -d
-                  docker inspect nginx | jq -e '.[0].HostConfig.RestartPolicy.Name == "unless-stopped"'
+                  CID=$(docker compose -f config/docker-compose.yaml ps -q nginx)
+                  docker inspect "$CID" | jq -e '.[0].HostConfig.RestartPolicy.Name == "unless-stopped"'
                   ./stamusctl compose down
                   ./stamusctl config set globals.restartmode=always
                   ./stamusctl compose up -d
-                  docker inspect nginx | jq -e '.[0].HostConfig.RestartPolicy.Name == "always"'
+                  CID=$(docker compose -f config/docker-compose.yaml ps -q nginx)
+                  docker inspect "$CID" | jq -e '.[0].HostConfig.RestartPolicy.Name == "always"'
 
     test-config-get-keys:
         name: Test Config Get Keys

--- a/internal/handlers/compose/readPcap.go
+++ b/internal/handlers/compose/readPcap.go
@@ -9,19 +9,24 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 
 	// Internal
 
-	"stamus-ctl/internal/app"
-	"stamus-ctl/internal/docker"
+    "stamus-ctl/internal/app"
+    composewrap "stamus-ctl/internal/docker-compose"
+    "stamus-ctl/internal/docker"
 	"stamus-ctl/internal/logging"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
 )
 
 type ReadPcapParams struct {
@@ -41,7 +46,7 @@ func initCli() *client.Client {
 	return cli
 }
 
-func createConfig(configName, pcap string) (container.Config, container.HostConfig, network.NetworkingConfig, error) {
+func createConfig(configName, pcap string, image string) (container.Config, container.HostConfig, network.NetworkingConfig, error) {
 	splitted := strings.Split(pcap, "/")
 	pcapName := splitted[len(splitted)-1]
 
@@ -51,7 +56,7 @@ func createConfig(configName, pcap string) (container.Config, container.HostConf
 	}
 
 	config := container.Config{
-		Image:      "jasonish/suricata:master-amd64-profiling",
+		Image:      image,
 		Entrypoint: []string{"/docker-entrypoint.sh"},
 		Cmd: []string{"-vvv -k none -r /replay/" + pcapName +
 			" --runmode autofp -l /var/log/suricata --set sensor-name=" + pcapName},
@@ -98,13 +103,19 @@ func runContainer(configName, pcap string) (string, error) {
 	logger := logging.Sugar.With("name", "suricata-readpcap")
 	cli := initCli()
 	ctx := context.Background()
-	config, hostConfig, networkConfig, err := createConfig(configName, pcap)
+	// Resolve suricata image from compose or fallback to default
+	image, err := resolveSuricataImage(configName)
+	if err != nil {
+		logger.With("error", err).Warn("image resolution failed; using default")
+	}
+	config, hostConfig, networkConfig, err := createConfig(configName, pcap, image)
 	if err != nil {
 		logger.With("error", err).Error("container configs")
 		return "", err
 	}
 
-	_, err = docker.PullImageIfNotExisted("jasonish/", "suricata:master-amd64-profiling")
+	reg, name := splitImageRef(image)
+	_, err = docker.PullImageIfNotExisted(reg, name)
 	if err != nil {
 		logger.With("error", err).Error("image pull")
 		return "", err
@@ -158,6 +169,95 @@ func runContainer(configName, pcap string) (string, error) {
 		_, _ = out.Read(dat)
 		fmt.Fprint(w, string(dat))
 	}
+}
+
+// resolveSuricataImage attempts to read the Suricata image from the instance compose file.
+// Falls back to default if not found or on error.
+func resolveSuricataImage(configPath string) (string, error) {
+	// Optional override via env for emergencies
+	logger := logging.Sugar.With("name", "resolve-suricata-image")
+	if env := os.Getenv("STAMUSCTL_SURICATA_IMAGE"); strings.TrimSpace(env) != "" {
+		return env, nil
+	}
+
+	// 1) Try effective compose config (handles multi-file setups)
+	if img := resolveImageViaComposeConfig(configPath); img != "" {
+		logger.With("image", img).Debug("resolved via docker compose config")
+		return img, nil
+	}
+
+    // 2) Fallback: parse a single compose file for services.suricata.image
+    compose := composewrap.GetComposeFilePath(configPath)
+	logger.With("compose", compose).Debug("found compose file")
+
+	b, err := afero.ReadFile(app.FS, compose)
+	if err != nil {
+		return defaultSuricataImage, err
+	}
+
+	type svc struct {
+		Image string `yaml:"image"`
+	}
+	var payload struct {
+		Services map[string]svc `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(b, &payload); err != nil {
+		return defaultSuricataImage, err
+	}
+	if payload.Services == nil {
+		return defaultSuricataImage, errors.New("compose missing services")
+	}
+	s, ok := payload.Services["suricata"]
+	if !ok || strings.TrimSpace(s.Image) == "" {
+		return defaultSuricataImage, errors.New("suricata image not found in compose")
+	}
+	logger.With("image", s.Image).Debug("resolved suricata image")
+	return s.Image, nil
+}
+
+// resolveImageViaComposeConfig runs `docker compose -f <file> config` to get the fully
+// resolved compose configuration, then extracts services.suricata.image.
+func resolveImageViaComposeConfig(configPath string) string {
+    composeFile := composewrap.GetComposeFilePath(configPath)
+	// Run from the compose file directory and reference the file by basename
+	fileDir := filepath.Dir(composeFile)
+	fileName := filepath.Base(composeFile)
+	logging.Sugar.With("dir", fileDir, "file", fileName).Debug("resolving via compose config")
+	cmd := exec.Command("docker", "compose", "-f", fileName, "config")
+	cmd.Dir = fileDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		logging.Sugar.With("error", err).With("out", string(out)).Info("docker compose config")
+		return ""
+	}
+	type svc struct {
+		Image string `yaml:"image"`
+	}
+	var payload struct {
+		Services map[string]svc `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(out, &payload); err != nil {
+		return ""
+	}
+	if s, ok := payload.Services["suricata"]; ok {
+		if strings.TrimSpace(s.Image) != "" {
+			return s.Image
+		}
+	}
+	return ""
+}
+
+var defaultSuricataImage = "jasonish/suricata:master-amd64"
+
+// splitImageRef splits an image reference into a registry-like prefix and the remainder name:tag.
+// Example: "ghcr.io/org/repo:tag" -> ("ghcr.io/org/", "repo:tag"); "jasonish/suricata:tag" -> ("jasonish/", "suricata:tag")
+// If there is no slash, returns ("", image).
+func splitImageRef(image string) (string, string) {
+	idx := strings.LastIndex(image, "/")
+	if idx == -1 {
+		return "", image
+	}
+	return image[:idx+1], image[idx+1:]
 }
 
 func PcapHandler(params ReadPcapParams) error {

--- a/internal/handlers/compose/readPcap_test.go
+++ b/internal/handlers/compose/readPcap_test.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+    "os"
+    "testing"
+
+    "github.com/spf13/afero"
+    "stamus-ctl/internal/app"
+)
+
+func TestSplitImageRef(t *testing.T) {
+    cases := []struct {
+        in       string
+        wantReg  string
+        wantName string
+    }{
+        {"ghcr.io/org/repo:tag", "ghcr.io/org/", "repo:tag"},
+        {"jasonish/suricata:master-amd64", "jasonish/", "suricata:master-amd64"},
+        {"repo:tag", "", "repo:tag"},
+        {"localhost:5000/repo:tag", "localhost:5000/", "repo:tag"},
+        {"myreg.io/team/app@sha256:deadbeef", "myreg.io/team/", "app@sha256:deadbeef"},
+    }
+    for _, c := range cases {
+        reg, name := splitImageRef(c.in)
+        if reg != c.wantReg || name != c.wantName {
+            t.Fatalf("splitImageRef(%q) = (%q,%q), want (%q,%q)", c.in, reg, name, c.wantReg, c.wantName)
+        }
+    }
+}
+
+func TestResolveSuricataImage_FromCompose(t *testing.T) {
+    // Ensure tests use in-memory FS
+    app.FS = afero.NewMemMapFs()
+
+    // Create instance path and compose file
+    instPath := "/instance-a"
+    if err := app.FS.MkdirAll(instPath, 0o755); err != nil {
+        t.Fatalf("mkdir: %v", err)
+    }
+
+    compose := `services:
+  suricata:
+    image: ghcr.io/stamusnetworks/suricata:1.2.3
+  other:
+    image: busybox
+`
+    if err := afero.WriteFile(app.FS, instPath+"/docker-compose.yaml", []byte(compose), 0o644); err != nil {
+        t.Fatalf("write compose: %v", err)
+    }
+
+    got, err := resolveSuricataImage(instPath)
+    if err != nil {
+        t.Fatalf("resolveSuricataImage error: %v", err)
+    }
+    want := "ghcr.io/stamusnetworks/suricata:1.2.3"
+    if got != want {
+        t.Fatalf("resolveSuricataImage got %q, want %q", got, want)
+    }
+}
+
+func TestResolveSuricataImage_EnvOverride(t *testing.T) {
+    // Ensure tests use in-memory FS
+    app.FS = afero.NewMemMapFs()
+
+    // Set env override
+    os.Setenv("STAMUSCTL_SURICATA_IMAGE", "override/repo:latest")
+    defer os.Unsetenv("STAMUSCTL_SURICATA_IMAGE")
+
+    got, err := resolveSuricataImage("/does-not-matter")
+    if err != nil {
+        t.Fatalf("resolveSuricataImage error with env override: %v", err)
+    }
+    if got != "override/repo:latest" {
+        t.Fatalf("env override not applied, got %q", got)
+    }
+}
+
+func TestResolveSuricataImage_Fallback(t *testing.T) {
+    // Ensure tests use in-memory FS
+    app.FS = afero.NewMemMapFs()
+
+    // No compose present -> fallback to defaultSuricataImage
+    got, _ := resolveSuricataImage("/missing-instance")
+    if got != defaultSuricataImage {
+        t.Fatalf("expected fallback to %q, got %q", defaultSuricataImage, got)
+    }
+}
+

--- a/internal/models/parameter.go
+++ b/internal/models/parameter.go
@@ -191,11 +191,21 @@ func (p *Parameter) validateChoices() bool {
 			for _, choice := range p.Choices {
 				asStrings = append(asStrings, *choice.String)
 			}
-			// Add as list
-			def := strings.Join(asStrings, ",")
-			asStrings = append(asStrings, def)
-			// Check
-			isOk := slices.Contains(asStrings, *p.Variable.String)
+			// Support comma-separated values: split and validate each against choices
+			val := strings.TrimSpace(*p.Variable.String)
+			if strings.Contains(val, ",") {
+				parts := strings.Split(val, ",")
+				for i := range parts {
+					parts[i] = strings.TrimSpace(parts[i])
+					if !slices.Contains(asStrings, parts[i]) {
+						logging.Sugar.Info("Error: Must be one of:", asStrings)
+						return false
+					}
+				}
+				return true
+			}
+			// Single value case
+			isOk := slices.Contains(asStrings, val)
 			if !isOk {
 				logging.Sugar.Info("Error: Must be one of:", asStrings)
 			}

--- a/internal/models/parameter_choices_test.go
+++ b/internal/models/parameter_choices_test.go
@@ -1,0 +1,40 @@
+package models
+
+import "testing"
+
+func TestValidateChoices_CommaSeparatedStrings(t *testing.T) {
+	param := &Parameter{
+		Name:         "suricata.interfaces",
+		Type:         "string",
+		ValidateFunc: func(v Variable) bool { return true },
+		Choices: []Variable{
+			CreateVariableString("lo"),
+			CreateVariableString("eth0"),
+			CreateVariableString("eth1"),
+		},
+	}
+
+	// Single valid
+	param.Variable = CreateVariableString("lo")
+	if !param.IsValid() {
+		t.Fatalf("expected single valid choice to pass")
+	}
+
+	// Multiple valid (duplicates allowed)
+	param.Variable = CreateVariableString("lo,lo")
+	if !param.IsValid() {
+		t.Fatalf("expected comma-separated duplicates to pass")
+	}
+
+	// Multiple valid mixed
+	param.Variable = CreateVariableString("eth0, lo")
+	if !param.IsValid() {
+		t.Fatalf("expected comma-separated trimmed values to pass")
+	}
+
+	// Contains invalid
+	param.Variable = CreateVariableString("eth0,eno1")
+	if param.IsValid() {
+		t.Fatalf("expected invalid value in list to fail")
+	}
+}

--- a/internal/stamus/instances.go
+++ b/internal/stamus/instances.go
@@ -2,11 +2,14 @@ package stamus
 
 import (
 	"bytes"
+	"encoding/json"
 	"os/exec"
 	"strings"
+	"unicode"
 
 	"stamus-ctl/internal/app"
 	compose "stamus-ctl/internal/docker-compose"
+	"stamus-ctl/internal/models"
 
 	"github.com/spf13/afero"
 )
@@ -34,34 +37,141 @@ func GetInstances() (Instances, error) {
 		// File exists
 		exists, _ := afero.Exists(app.FS, file)
 		if !exists {
-			RemoveInstance(file)
+			// Remove instance by its folder, not compose file path
+			RemoveInstance(string(folder))
 			continue
 		}
-		// Check if up
+		// Determine seed and check by docker ps first (match by name containing seed)
+		seed := getInstanceSeed(string(folder))
 		var outBuf, errBuf bytes.Buffer
-		cmd := exec.Command("docker", "compose", "-f", file, "ps")
-		cmd.Stdout = &outBuf
-		cmd.Stderr = &errBuf
-		err := cmd.Run()
-		if err != nil {
-			return nil, err
+		if seed != "" {
+			cmd := exec.Command("docker", "ps", "--format", "json", "--filter", "name="+seed)
+			cmd.Stdout = &outBuf
+			cmd.Stderr = &errBuf
+			if err := cmd.Run(); err != nil {
+				return nil, err
+			}
 		}
-		// Prepare data
-		if strings.Contains(outBuf.String(), "Up") {
+		// If ps via seed indicates running, mark up. Otherwise, fallback to compose-scoped ps.
+		if isComposeUpFromPs(outBuf.String()) {
 			instancesInfos[folder] = Infos{
 				Project: infos.Project,
 				Version: infos.Version,
 				IsUp:    true,
 			}
 		} else {
-			instancesInfos[folder] = Infos{
-				Project: infos.Project,
-				Version: infos.Version,
-				IsUp:    false,
+			// Fallback: docker compose ps scoped to this instance's compose file
+			var cOut, cErr bytes.Buffer
+			cfile := compose.GetComposeFilePath(string(folder))
+			ccmd := exec.Command("docker", "compose", "-f", cfile, "ps", "--format", "json")
+			ccmd.Stdout = &cOut
+			ccmd.Stderr = &cErr
+			if err := ccmd.Run(); err != nil {
+				// If compose fails, treat as down
+				instancesInfos[folder] = Infos{Project: infos.Project, Version: infos.Version, IsUp: false}
+			} else if isComposeUpFromPs(cOut.String()) {
+				instancesInfos[folder] = Infos{Project: infos.Project, Version: infos.Version, IsUp: true}
+			} else {
+				instancesInfos[folder] = Infos{Project: infos.Project, Version: infos.Version, IsUp: false}
 			}
 		}
 	}
 	return instancesInfos, nil
+}
+
+// isComposeUpFromPs determines if any service is running based on `docker compose ps` output.
+// It supports JSON output from Compose V2 and falls back to substring checks.
+func isComposeUpFromPs(output string) bool {
+	s := strings.TrimSpace(output)
+	if s == "" {
+		return false
+	}
+	// Try JSON array from `--format json`
+	if strings.HasPrefix(s, "[") {
+		var items []map[string]any
+		if err := json.Unmarshal([]byte(s), &items); err == nil {
+			for _, it := range items {
+				// Check common fields
+				if state, ok := it["State"].(string); ok {
+					if strings.EqualFold(state, "running") || strings.EqualFold(state, "healthy") {
+						return true
+					}
+				}
+				if status, ok := it["Status"].(string); ok {
+					ls := strings.ToLower(status)
+					if strings.Contains(ls, "running") || strings.Contains(ls,
+						"healthy") || strings.Contains(ls, "up") {
+						return true
+					}
+				}
+			}
+			return false
+		}
+		// If JSON parsing fails, fall back to string checks
+	}
+	// Try JSON-per-line (one object per line)
+	lines := strings.Split(s, "\n")
+	parsedAny := false
+	for _, line := range lines {
+		ln := strings.TrimSpace(line)
+		if ln == "" {
+			continue
+		}
+		if strings.HasPrefix(ln, "{") && strings.HasSuffix(ln, "}") {
+			var it map[string]any
+			if err := json.Unmarshal([]byte(ln), &it); err == nil {
+				parsedAny = true
+				if state, ok := it["State"].(string); ok {
+					if strings.EqualFold(state, "running") || strings.EqualFold(state, "healthy") {
+						return true
+					}
+				}
+				if status, ok := it["Status"].(string); ok {
+					ls := strings.ToLower(status)
+					if strings.Contains(ls, "running") || strings.Contains(ls,
+						"healthy") || strings.Contains(ls, "up") {
+						return true
+					}
+				}
+			}
+		}
+	}
+	if parsedAny {
+		return false
+	}
+	// Fallback: scan lines and consider a status token equal to "up"/"running"/"healthy"
+	for _, line := range lines {
+		ln := strings.TrimFunc(line, unicode.IsSpace)
+		if ln == "" {
+			continue
+		}
+		lnl := strings.ToLower(ln)
+		// Ignore header rows
+		if strings.Contains(lnl, "status") && strings.Contains(lnl, "name") {
+			continue
+		}
+		// Tokenize and look for specific status words
+		fields := strings.Fields(lnl)
+		for _, f := range fields {
+			if f == "up" || f == "running" || f == "healthy" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// getInstanceSeed reads the instance seed from its values.yaml (stamus.seed)
+func getInstanceSeed(folder string) string {
+	file, err := models.CreateFile(folder, "values.yaml")
+	if err != nil {
+		return ""
+	}
+	conf, err := models.LoadConfigFrom(file, true)
+	if err != nil {
+		return ""
+	}
+	return conf.GetSeed()
 }
 
 func AddInstance(folder string, project string, version string) error {

--- a/internal/stamus/instances_test.go
+++ b/internal/stamus/instances_test.go
@@ -1,0 +1,55 @@
+package stamus
+
+import "testing"
+
+func TestIsComposeUpFromPs_JSONRunning(t *testing.T) {
+	out := `[
+        {"Name":"a","State":"running","Status":"running"},
+        {"Name":"b","State":"exited","Status":"exited"}
+    ]`
+	if !isComposeUpFromPs(out) {
+		t.Fatalf("expected running=true for JSON output")
+	}
+}
+
+func TestIsComposeUpFromPs_JSONExited(t *testing.T) {
+	out := `[{"Name":"a","State":"exited","Status":"exited"}]`
+	if isComposeUpFromPs(out) {
+		t.Fatalf("expected running=false for exited JSON output")
+	}
+}
+
+func TestIsComposeUpFromPs_TextUp(t *testing.T) {
+	out := "NAME\tSERVICE\tSTATUS\nweb\tweb\tUp 2 minutes"
+	if !isComposeUpFromPs(out) {
+		t.Fatalf("expected running=true for text containing Up")
+	}
+}
+
+func TestIsComposeUpFromPs_TextRunning(t *testing.T) {
+	out := "NAME SERVICE STATUS\nweb web running 2m"
+	if !isComposeUpFromPs(out) {
+		t.Fatalf("expected running=true for text containing running")
+	}
+}
+
+func TestIsComposeUpFromPs_Empty(t *testing.T) {
+	if isComposeUpFromPs("") {
+		t.Fatalf("expected running=false for empty output")
+	}
+}
+
+func TestIsComposeUpFromPs_TextNoRunning(t *testing.T) {
+	out := "NAME\tSERVICE\tSTATUS\nweb\tweb\tExited (0) 3 minutes ago"
+	if isComposeUpFromPs(out) {
+		t.Fatalf("expected running=false for exited text output")
+	}
+}
+
+func TestIsComposeUpFromPs_JSONLines(t *testing.T) {
+	out := `{"Name":"a","State":"exited","Status":"exited"}
+{"Name":"b","State":"running","Status":"running"}`
+	if !isComposeUpFromPs(out) {
+		t.Fatalf("expected running=true for JSON-per-line output")
+	}
+}


### PR DESCRIPTION
- suricata.interfaces=lo,lo dont work because we did not parse string as multiple interfaces if "," is in the string
- readpcap feature was not using the same suricata image as in the template. Added a parser that find the image and use this one
- config list now works a bit better. Seems still buggy in some edge conditions